### PR TITLE
add drag to reorder pages in sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vueuse/core": "^13.7.0",
+        "@vueuse/integrations": "^14.2.1",
         "idb": "^8.0.3",
         "jspdf": "^3.0.1",
         "konva": "^9.3.22",
@@ -16,6 +17,7 @@
         "lucide-vue-next": "^0.541.0",
         "pinia": "^3.0.3",
         "pixi.js": "^8.12.0",
+        "sortablejs": "^1.15.7",
         "vue": "^3.5.18",
         "vue-konva": "^3.2.4",
         "vue-router": "^4.5.1"
@@ -23,6 +25,7 @@
       "devDependencies": {
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.11.30",
+        "@types/sortablejs": "^1.15.9",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.7.0",
         "typescript": "^5.6.3",
@@ -832,6 +835,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+      "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -1089,6 +1099,110 @@
         "@vueuse/metadata": "13.7.0",
         "@vueuse/shared": "13.7.0"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.2.1.tgz",
+      "integrity": "sha512-2LIUpBi/67PoXJGqSDQUF0pgQWpNHh7beiA+KG2AbybcNm+pTGWT6oPGlBgUoDWmYwfeQqM/uzOHqcILpKL7nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7 || ^8",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
+      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
@@ -1722,6 +1836,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.48.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^13.7.0",
+    "@vueuse/integrations": "^14.2.1",
     "idb": "^8.0.3",
     "jspdf": "^3.0.1",
     "konva": "^9.3.22",
@@ -22,6 +23,7 @@
     "lucide-vue-next": "^0.541.0",
     "pinia": "^3.0.3",
     "pixi.js": "^8.12.0",
+    "sortablejs": "^1.15.7",
     "vue": "^3.5.18",
     "vue-konva": "^3.2.4",
     "vue-router": "^4.5.1"
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.11.30",
+    "@types/sortablejs": "^1.15.9",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.7.0",
     "typescript": "^5.6.3",

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -9,7 +9,7 @@
       </button>
     </div>
 
-    <div class="pages-grid">
+    <div class="pages-grid" ref="pagesGridRef">
       <div 
         v-for="(page, index) in projectStore.currentProject?.pages" 
         :key="page.id"
@@ -45,7 +45,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { useSortable } from '@vueuse/integrations/useSortable';
 import { useProjectStore } from '@/stores/project';
 import { useUIStore } from '@/stores/ui';
 import { useAssetStore } from '@/stores/assetStore';
@@ -58,6 +59,24 @@ const assetStore = useAssetStore();
 
 const editingId = ref<string | null>(null);
 const editValue = ref('');
+
+const pagesGridRef = ref<HTMLElement | null>(null);
+const pageIds = computed(() => projectStore.currentProject?.pages.map(p => p.id) ?? []);
+
+useSortable(pagesGridRef, pageIds, {
+  animation: 150,
+  ghostClass: 'sortable-ghost',
+  chosenClass: 'sortable-chosen',
+  dragClass: 'sortable-drag',
+  filter: '.title-input',
+  preventOnFilter: false,
+  onEnd(evt) {
+    const { oldIndex, newIndex } = evt;
+    if (oldIndex != null && newIndex != null && oldIndex !== newIndex) {
+      projectStore.reorderPages(oldIndex, newIndex);
+    }
+  },
+});
 
 function pageTitle(page: any): string {
   const tpl = projectStore.currentProject?.template;
@@ -184,8 +203,28 @@ async function exportZine(): Promise<void> {
   padding: 0.5rem;
   border: 2px solid transparent;
   border-radius: 6px;
-  cursor: pointer;
+  cursor: grab;
   transition: all 0.2s ease;
+}
+
+.page-item:active {
+  cursor: grabbing;
+}
+
+.page-item.sortable-ghost {
+  opacity: 0.3;
+  border-color: #000;
+  border-style: dashed;
+}
+
+.page-item.sortable-chosen {
+  box-shadow: 3px 3px 0 #000;
+  border-color: #000;
+  background: #e7ffe7;
+}
+
+.page-item.sortable-drag {
+  opacity: 0.9;
 }
 
 .page-item:hover {

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -547,6 +547,52 @@ export const useProjectStore = defineStore('project', () => {
     return 'export-data';
   }
 
+  function reorderPages(fromIndex: number, toIndex: number): void {
+    if (!currentProject.value) return;
+    const pages = currentProject.value.pages;
+    if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= pages.length || toIndex >= pages.length) return;
+
+    const prevPages = JSON.parse(JSON.stringify(pages)) as ZinePage[];
+    const prevPageIndex = currentPageIndex.value;
+
+    const [moved] = pages.splice(fromIndex, 1);
+    pages.splice(toIndex, 0, moved);
+    pages.forEach((p, i) => { p.pageNumber = i + 1; });
+
+    // Follow the currently-viewed page
+    if (currentPageIndex.value === fromIndex) {
+      currentPageIndex.value = toIndex;
+    } else if (fromIndex < currentPageIndex.value && toIndex >= currentPageIndex.value) {
+      currentPageIndex.value--;
+    } else if (fromIndex > currentPageIndex.value && toIndex <= currentPageIndex.value) {
+      currentPageIndex.value++;
+    }
+
+    isModified.value = true;
+
+    const newPageIndex = currentPageIndex.value;
+    pushHistory({
+      name: 'reorderPages',
+      undo: () => {
+        if (!currentProject.value) return;
+        currentProject.value.pages = prevPages.map(p => {
+          const existing = currentProject.value!.pages.find(ep => ep.id === p.id);
+          return existing ? Object.assign(existing, p) : p;
+        });
+        currentProject.value.pages = JSON.parse(JSON.stringify(prevPages));
+        currentPageIndex.value = prevPageIndex;
+      },
+      redo: () => {
+        if (!currentProject.value) return;
+        const pages = currentProject.value.pages;
+        const [moved] = pages.splice(fromIndex, 1);
+        pages.splice(toIndex, 0, moved);
+        pages.forEach((p, i) => { p.pageNumber = i + 1; });
+        currentPageIndex.value = newPageIndex;
+      }
+    });
+  }
+
   function renamePage(pageId: string, newTitle: string): void {
     if (!currentProject.value) return;
     const page = currentProject.value.pages.find(p => p.id === pageId);
@@ -589,8 +635,8 @@ export const useProjectStore = defineStore('project', () => {
     manualSave,
     getContentById,
     duplicateContent,
-    exportProject
-    ,
+    exportProject,
+    reorderPages,
     renamePage
   };
 });


### PR DESCRIPTION
## Summary

- Adds drag-and-drop reordering of pages in the left sidebar using SortableJS (via `@vueuse/integrations/useSortable`)
- Adds `reorderPages(fromIndex, toIndex)` action to the project store with full undo/redo support
- After reorder, `pageNumber` is reassigned sequentially so export/print imposition reflects the new page order
- Works on both desktop and touch devices

## Motivation

Users often need to rearrange pages after designing them (e.g., moving a poem to a different position in a zine). Previously there was no way to do this without recreating pages manually.

## Changes

- `package.json` — added `sortablejs`, `@vueuse/integrations`, `@types/sortablejs`
- `src/stores/project.ts` — new `reorderPages` action with undo/redo, `currentPageIndex` tracking
- `src/components/PageList.vue` — integrated `useSortable`, added drag handle styling (ghost, chosen, drag classes)