### PR TITLE
fix lineHeight, textDecoration, and padding not applied to text

### DIFF
--- a/src/components/KonvaPageEditor.vue
+++ b/src/components/KonvaPageEditor.vue
@@ -285,6 +285,9 @@ watch(() => projectStore.currentPage?.content, async (content) => {
           fontStyle: `${p.fontStyle} ${p.fontWeight}`.trim(),
           fill: p.color,
           align: p.textAlign,
+          lineHeight: p.lineHeight,
+          textDecoration: p.textDecoration !== 'none' ? p.textDecoration : '',
+          padding: p.padding,
           visible: isVisible,
           draggable: toolsStore.activeTool === 'select' && isSelected && !isLocked,
           listening: !isLocked

--- a/src/composables/useZineExport.ts
+++ b/src/composables/useZineExport.ts
@@ -247,7 +247,7 @@ export async function createKonvaNode(content: ZineContent, getAsset: GetAssetFn
 
   if (content.type === 'text') {
     const p = content.properties as TextProperties;
-    return new Konva.Text({ ...common, text: p.text, fontSize: p.fontSize, fontFamily: p.fontFamily, fontStyle: `${p.fontStyle} ${p.fontWeight}`.trim(), fill: p.color, align: p.textAlign });
+    return new Konva.Text({ ...common, text: p.text, fontSize: p.fontSize, fontFamily: p.fontFamily, fontStyle: `${p.fontStyle} ${p.fontWeight}`.trim(), fill: p.color, align: p.textAlign, lineHeight: p.lineHeight, textDecoration: p.textDecoration !== 'none' ? p.textDecoration : '', padding: p.padding });
   }
 
   if (content.type === 'image') {


### PR DESCRIPTION
## Summary

- Fixes `lineHeight`, `textDecoration`, and `padding` not being passed to Konva text nodes
- Affects both the editor canvas and the export renderer

## Motivation

`TextProperties` defines `lineHeight`, `textDecoration`, and `padding`, and the properties panel allows editing them, but they were never included in the Konva node config. Konva used its defaults (lineHeight 1, no decoration, no padding) regardless of what the user set.

## Changes

- `src/components/KonvaPageEditor.vue` — added `lineHeight`, `textDecoration`, `padding` to the text node config
- `src/composables/useZineExport.ts` — same fix for the off-screen export renderer